### PR TITLE
Set McpServerGUI as default package

### DIFF
--- a/upp-mcpserver.upp
+++ b/upp-mcpserver.upp
@@ -1,25 +1,21 @@
 // Main U++ package file for the MCP Server project
-// TEMPORARILY MODIFIED FOR MINIMAL WEBSOCKET TEST
-
 uses
-	Core,
-	CtrlLib;
+        Core,
+        CtrlLib;
 
-/*
 group "Library";
-	package mcp_server_lib type static_library uses Core file "mcp_server_lib/mcp_server_lib.upp";
+        package mcp_server_lib type static_library uses Core file "mcp_server_lib/mcp_server_lib.upp";
 
 group "Application";
-	package McpServerGUI type executable uses Core, CtrlLib, mcp_server_lib file "McpServerGUI/McpServerGUI.upp";
+        package McpServerGUI type executable uses Core, CtrlLib, mcp_server_lib file "McpServerGUI/McpServerGUI.upp";
 
 group "Plugins";
 group "Tests";
-*/
 
-group "Minimal WebSocket Tests";
-	package MinimalWsServer type executable uses Core file "minimalserver/MinimalWsServer.upp";
-	package MinimalWsClient type executable uses Core file "minimalclient/MinimalWsClient.upp";
+group "Minimal WebSocket Tests"; // Optional examples
+        package MinimalWsServer type executable uses Core file "minimalserver/MinimalWsServer.upp";
+        package MinimalWsClient type executable uses Core file "minimalclient/MinimalWsClient.upp";
 
-main_package "MinimalWsServer"; // Explicitly set MinimalWsServer as a default target
+main_package "McpServerGUI";
 
 cxxflags "-std=c++17";


### PR DESCRIPTION
## Summary
- restore original packages in `upp-mcpserver.upp`
- keep minimal websocket examples as optional packages

## Testing
- `cmake -S . -B build` *(fails: The source directory does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6845663f6508832ea83ec434033b6dc7