### PR TITLE
Refactor tests to use simple TEST macros

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(McpServerTests)
 
-# This CMakeLists.txt would typically:
-# 1. Find a C++ test framework (like Google Test, Catch2, or U++'s own Test:: UnitTest)
-# 2. Add executables for each test file or a combined test runner.
-# 3. Link against the mcp_server_lib and the test framework.
+add_executable(McpServerTests
+    test_main.cpp
+    test_sandbox.cpp
+    test_permissions.cpp
+)
 
-# Placeholder for U++ Test++ integration or other framework
-# add_executable(SandboxTests test_sandbox.cpp)
-# target_link_libraries(SandboxTests PRIVATE mcp_server_lib UPP::Core Test::UnitTest)
-
-# add_executable(PermissionTests test_permissions.cpp)
-# target_link_libraries(PermissionTests PRIVATE mcp_server_lib UPP::Core Test::UnitTest)
-
-# Example using U++ Test::UnitTest (if available and configured)
-# ASSISTANT_NOTE: U++ Test framework is Test::
-# For now, just a comment indicating where test registration would go.
-# If using U++'s own test framework, usually it's integrated via .upp files.
+target_include_directories(McpServerTests PRIVATE ${CMAKE_SOURCE_DIR}/include)
+# Link against core server library when available
+# target_link_libraries(McpServerTests PRIVATE mcp_server_lib)

--- a/tests/McpServerTests.upp
+++ b/tests/McpServerTests.upp
@@ -1,38 +1,16 @@
 // U++ Package file for McpServerTests
-
 name "McpServerTests";
-type executable; // Console executable for running tests
+type executable;
 
 uses
-	Core,
-	Test, // U++ Test framework
-	mcp_server_lib; // Depends on our core server library for testing its components
-
-// List of test files.
-// If each test_*.cpp is a separate TEST_APP_MAIN or CONSOLE_APP_MAIN,
-// then each would need to be its own executable or linked into a test runner.
-// For simplicity with U++ Test framework, often all test files are compiled
-// into a single executable that runs all tests.
-// The U++ Test package itself provides a main for this if files contain TEST_CASEs.
+    Core,
+    Test,
+    mcp_server_lib;
 
 file
-	"test_sandbox.cpp",
-	"test_permissions.cpp";
-	// If more test files are added, list them here.
+    "test_helpers.h", // header only
+    "test_sandbox.cpp",
+    "test_permissions.cpp",
+    "test_main.cpp";
 
 cxxflags "-std=c++17";
-
-// When using the "Test" package from U++, it often provides a main entry point
-// that automatically runs all TEST_CASEs found in the linked files.
-// So, individual test_*.cpp files should use TEST_CASE(...) for their tests,
-// and not necessarily have their own CONSOLE_APP_MAIN if using Test package's runner.
-// The stubs I created for test_sandbox.cpp and test_permissions.cpp currently
-// have CONSOLE_APP_MAIN. This will need to be refactored if using Test:: globally.
-// For now, this .upp file will make them linkable. If they are separate mains,
-// TheIDE would build them as separate targets if this .upp was structured differently
-// (e.g. one .upp per test file or using custom build steps).
-// Given 'type executable' and multiple .cpp files, this implies they are part of the
-// same executable. One of them must supply the main() or Test package does.
-// Let's assume for now the Test package will provide the main and run tests from both files.
-// This means test_*.cpp files should be refactored to use TEST_CASEs instead of CONSOLE_APP_MAIN.
-// This refactoring is outside the scope of this "create .upp file" step.

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,50 @@
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+#include <Core/Core.h>
+
+using namespace Upp;
+
+class TestRunner {
+public:
+    using TestFunc = void(*)();
+    Vector<std::pair<String, TestFunc>> tests;
+    static TestRunner& Instance() { static TestRunner r; return r; }
+    void Add(const String& name, TestFunc f) { tests.Add(std::make_pair(name, f)); }
+    int Run() {
+        StdLogSetup(LOG_COUT|LOG_FILE);
+        int errors = 0;
+        for(auto& t : tests) {
+            LOG("Running: " + t.first);
+            try {
+                t.second();
+                LOG("  OK");
+            } catch(const Exc& e) {
+                LOG("  FAILED: " + String(e));
+                errors++;
+            } catch(...) {
+                LOG("  FAILED: unknown exception");
+                errors++;
+            }
+        }
+        return errors;
+    }
+};
+
+#define TEST(name) \
+    static void name(); \
+    static struct name##_registrar { name##_registrar() { TestRunner::Instance().Add(#name, &name); } } name##_registrar_instance; \
+    static void name()
+
+#define TEST_APP_MAIN \
+    CONSOLE_APP_MAIN \
+    { \
+        int errors = TestRunner::Instance().Run(); \
+        if(errors) { \
+            LOG(Format("%d tests failed", errors)); \
+            SetExitCode(1); \
+        } else { \
+            LOG("All tests passed"); \
+        } \
+    }
+
+#endif // TEST_HELPERS_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,3 @@
+#include "test_helpers.h"
+
+TEST_APP_MAIN

--- a/tests/test_permissions.cpp
+++ b/tests/test_permissions.cpp
@@ -1,129 +1,59 @@
-/**
- * @file test_permissions.cpp
- * @brief Unit tests for McpServer permission flags.
- */
+#include "../include/McpServer.h"
+#include <Core/Core.h>
+#include "test_helpers.h"
 
-#include "../include/McpServer.h" // For McpServer class & Permissions struct
-#include <Core/Core.h>         // For U++ Core utilities, LOG, ASSERT
-#include <Test/Test.h>       // For U++ Test framework
-
-// Helper function to simulate a tool call that checks a specific permission
-// This is highly simplified. Real tool calls involve JSON args and results.
-bool SimulateToolCall(McpServer& server, bool (Permissions::*perm_flag), const String& actionName) {
-    LOG("  Simulating tool call requiring permission for: " + actionName);
-    if ((server.GetPermissions().*perm_flag)) {
-        LOG("    Permission GRANTED for " + actionName);
-        return true; // Allowed
-    } else {
-        LOG("    Permission DENIED for " + actionName);
-        // In a real tool, this would throw an exception.
-        // For this test, we just return false.
-        return false; // Denied
-    }
+bool SimulateToolCall(McpServer& server, bool (Permissions::*perm_flag), const String& action)
+{
+    return (server.GetPermissions().*perm_flag);
 }
 
-
-CONSOLE_APP_MAIN
+TEST(Permissions_DefaultFlagsFalse)
 {
-    StdLogSetup(LOG_COUT|LOG_TIMESTAMP);
-    int exit_code = 0;
+    McpServer server(1234,1);
+    const Permissions& p = server.GetPermissions();
+    ASSERT(!p.allowReadFiles && !p.allowWriteFiles && !p.allowExec);
+}
 
-    LOG("--- Permissions Unit Tests ---");
+TEST(Permissions_EnableSpecific)
+{
+    McpServer server(1234,1);
+    server.GetPermissions().allowReadFiles = true;
+    ASSERT(server.GetPermissions().allowReadFiles);
+    ASSERT(!server.GetPermissions().allowWriteFiles);
+    ASSERT(SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile"));
+    ASSERT(!SimulateToolCall(server, &Permissions::allowWriteFiles, "WriteFile"));
+}
 
-    // Test Case 1: Default permissions (all false)
-    {
-        LOG("Test Case 1: Default permissions.");
-        McpServer server(1234,1);
-        Permissions& perms = server.GetPermissions();
+TEST(Permissions_EnableMultiple)
+{
+    McpServer server(1234,1);
+    server.GetPermissions().allowWriteFiles = true;
+    server.GetPermissions().allowCreateDirs = true;
+    ASSERT(server.GetPermissions().allowWriteFiles);
+    ASSERT(server.GetPermissions().allowCreateDirs);
+    ASSERT(!server.GetPermissions().allowReadFiles);
+    ASSERT(SimulateToolCall(server, &Permissions::allowWriteFiles, "WriteFile"));
+    ASSERT(SimulateToolCall(server, &Permissions::allowCreateDirs, "CreateDir"));
+    ASSERT(!SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile"));
+}
 
-        ASSERT(!perms.allowReadFiles);
-        ASSERT(!perms.allowWriteFiles);
-        // ... assert all other permissions are false by default ...
-        ASSERT(!perms.allowExec);
-        LOG("  PASSED: Default permissions are all false.");
-    }
+TEST(Permissions_AllEnabled)
+{
+    McpServer server(1234,1);
+    Permissions& perms = server.GetPermissions();
+    perms.allowReadFiles=true; perms.allowWriteFiles=true; perms.allowDeleteFiles=true;
+    perms.allowRenameFiles=true; perms.allowCreateDirs=true; perms.allowSearchDirs=true;
+    perms.allowExec=true; perms.allowNetworkAccess=true; perms.allowExternalStorage=true;
+    perms.allowChangeAttributes=true; perms.allowIPC=true;
+    ASSERT(SimulateToolCall(server, &Permissions::allowReadFiles, "Read"));
+    ASSERT(SimulateToolCall(server, &Permissions::allowExec, "Exec"));
+}
 
-    // Test Case 2: Enable a specific permission (e.g., allowReadFiles)
-    {
-        LOG("Test Case 2: Enable allowReadFiles.");
-        McpServer server(1234,1);
-        server.GetPermissions().allowReadFiles = true;
-
-        ASSERT(server.GetPermissions().allowReadFiles);
-        ASSERT(!server.GetPermissions().allowWriteFiles); // Ensure others are still false
-        LOG("  PASSED: allowReadFiles is true, others default false.");
-
-        // Simulate a tool that needs this permission
-        if (!SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile")) {
-            LOG("  FAILED: ReadFile tool was denied when permission was true.");
-            exit_code=1;
-        }
-        ASSERT(SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile"));
-
-        if (SimulateToolCall(server, &Permissions::allowWriteFiles, "WriteFile")) {
-             LOG("  FAILED: WriteFile tool was allowed when permission was false.");
-             exit_code=1;
-        }
-        ASSERT(!SimulateToolCall(server, &Permissions::allowWriteFiles, "WriteFile"));
-    }
-
-    // Test Case 3: Enable multiple permissions
-    {
-        LOG("Test Case 3: Enable multiple permissions (allowWriteFiles, allowCreateDirs).");
-        McpServer server(1234,1);
-        server.GetPermissions().allowWriteFiles = true;
-        server.GetPermissions().allowCreateDirs = true;
-
-        ASSERT(server.GetPermissions().allowWriteFiles);
-        ASSERT(server.GetPermissions().allowCreateDirs);
-        ASSERT(!server.GetPermissions().allowReadFiles);
-        LOG("  PASSED: Multiple specific permissions are true.");
-
-        ASSERT(SimulateToolCall(server, &Permissions::allowWriteFiles, "WriteFile"));
-        ASSERT(SimulateToolCall(server, &Permissions::allowCreateDirs, "CreateDir"));
-        ASSERT(!SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile"));
-    }
-
-    // Test Case 4: All permissions enabled
-    {
-        LOG("Test Case 4: All permissions enabled.");
-        McpServer server(1234,1);
-        Permissions& perms = server.GetPermissions();
-        perms.allowReadFiles       = true;
-        perms.allowWriteFiles      = true;
-        perms.allowDeleteFiles     = true;
-        perms.allowRenameFiles     = true;
-        perms.allowCreateDirs      = true;
-        perms.allowSearchDirs      = true;
-        perms.allowExec            = true;
-        perms.allowNetworkAccess   = true;
-        perms.allowExternalStorage = true;
-        perms.allowChangeAttributes= true;
-        perms.allowIPC             = true;
-
-        ASSERT(SimulateToolCall(server, &Permissions::allowReadFiles, "ReadFile"));
-        ASSERT(SimulateToolCall(server, &Permissions::allowExec, "ExecuteProcess"));
-        // ... Test a few more ...
-        LOG("  PASSED: All permissions are true and respected.");
-    }
-
-    // Test Case 5: Modifying permissions through GetPermissions() reference
-    {
-        LOG("Test Case 5: Modifying through reference.");
-        McpServer server(1234,1);
-        Permissions& perms_ref = server.GetPermissions();
-        perms_ref.allowNetworkAccess = true;
-
-        ASSERT(server.GetPermissions().allowNetworkAccess);
-        ASSERT(SimulateToolCall(server, &Permissions::allowNetworkAccess, "NetworkCall"));
-        LOG("  PASSED: Modification via reference works.");
-    }
-
-
-    if (exit_code == 0) {
-        LOG("--- All Permission Tests PASSED ---");
-    } else {
-        LOG("--- Some Permission Tests FAILED ---");
-    }
-    SetExitCode(exit_code);
+TEST(Permissions_ModifyViaReference)
+{
+    McpServer server(1234,1);
+    Permissions& ref = server.GetPermissions();
+    ref.allowNetworkAccess = true;
+    ASSERT(server.GetPermissions().allowNetworkAccess);
+    ASSERT(SimulateToolCall(server, &Permissions::allowNetworkAccess, "Network"));
 }

--- a/tests/test_sandbox.cpp
+++ b/tests/test_sandbox.cpp
@@ -1,216 +1,96 @@
-/**
- * @file test_sandbox.cpp
- * @brief Unit tests for McpServer sandboxing (EnforceSandbox).
- */
+#include "../include/McpServer.h"
+#include <Core/Core.h>
+#include "test_helpers.h"
 
-#include "../include/McpServer.h" // For McpServer class
-#include <Core/Core.h>         // For U++ Core utilities, LOG, ASSERT
-#include <Test/Test.h>       // For U++ Test framework (TEST_CASE, EXPECT, etc.)
-                             // Or whatever test framework is chosen.
-                             // Using U++ Test:: syntax for this stub.
-
-// For U++ Test framework, tests are usually grouped using TEST_SUITE
-// and individual tests with TEST_CASE.
-// Or using `UNITTEST` macro for simpler cases.
-
-// Mock McpServer or use a real instance for testing EnforceSandbox
-// For EnforceSandbox, we primarily need to manipulate sandboxRoots.
-
-CONSOLE_APP_MAIN // Or GUI_APP_MAIN if tests need GUI context
+TEST(Sandbox_NoRootsAllowsAnyPath)
 {
-    StdLogSetup(LOG_COUT|LOG_TIMESTAMP);
-    int exit_code = 0;
+    McpServer server(1234, 1);
+    server.EnforceSandbox("/some/random/path/file.txt");
+    server.EnforceSandbox("C:/windows/system32/dangerous.dll");
+}
 
-    LOG("--- Sandbox Unit Tests ---");
+TEST(Sandbox_PathWithinRoot)
+{
+    McpServer server(1234, 1);
+    String root = NormalizePath(GetExeFolder() + "/test_sandbox_area_1");
+    RealizeDirectory(root);
+    server.AddSandboxRoot(root);
+    server.EnforceSandbox(AppendFileName(root, "file_allowed.txt"));
+    DeleteFolderDeep(root);
+}
 
-    // Test Case 1: No sandbox roots defined - should allow any path
-    {
-        LOG("Test Case 1: No sandbox roots - any path allowed.");
-        McpServer server(1234, 1); // Dummy port/clients for test
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox("/some/random/path/file.txt");
-            server.EnforceSandbox("C:/windows/system32/dangerous.dll");
-            LOG("  PASSED: No exception for unrestricted paths when no roots defined.");
-        } catch (const String& e) {
-            LOG("  FAILED: Exception thrown when no roots defined: " + e);
-            exception_thrown = true;
-            exit_code = 1;
-        }
-        ASSERT(!exception_thrown);
+TEST(Sandbox_PathOutsideRoot)
+{
+    McpServer server(1234, 1);
+    String root = NormalizePath(GetExeFolder() + "/test_sandbox_area_2");
+    RealizeDirectory(root);
+    server.AddSandboxRoot(root);
+    String outside = NormalizePath(GetExeFolder() + "/some_other_area/file_denied.txt");
+    bool threw = false;
+    try {
+        server.EnforceSandbox(outside);
+    } catch(...) {
+        threw = true;
     }
+    ASSERT(threw);
+    DeleteFolderDeep(root);
+}
 
-    // Test Case 2: Single sandbox root - path within root
-    {
-        LOG("Test Case 2: Path within a single sandbox root.");
-        McpServer server(1234, 1);
-        String root = NormalizePath(GetExeFolder() + "/test_sandbox_area_1");
-        RealizeDirectory(root); // Ensure it exists for the test
-        server.AddSandboxRoot(root);
-        LOG("  Added root: " + root);
-
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox(AppendFileName(root, "file_allowed.txt"));
-            LOG("  PASSED: No exception for path within the root.");
-        } catch (const String& e) {
-            LOG("  FAILED: Exception thrown for path within root: " + e);
-            exception_thrown = true;
-            exit_code = 1;
-        }
-        ASSERT(!exception_thrown);
-        DeleteFolderDeep(root); // Clean up
+TEST(Sandbox_MultipleRoots)
+{
+    McpServer server(1234, 1);
+    String root1 = NormalizePath(GetExeFolder() + "/test_sandbox_multi_1");
+    String root2 = NormalizePath(GetExeFolder() + "/test_sandbox_multi_2");
+    RealizeDirectory(root1); RealizeDirectory(root2);
+    server.AddSandboxRoot(root1);
+    server.AddSandboxRoot(root2);
+    server.EnforceSandbox(AppendFileName(root1, "file.txt"));
+    server.EnforceSandbox(AppendFileName(root2, "another.txt"));
+    bool threw = false;
+    try {
+        server.EnforceSandbox(NormalizePath(GetExeFolder() + "/outside_multi/other.txt"));
+    } catch(...) {
+        threw = true;
     }
+    ASSERT(threw);
+    DeleteFolderDeep(root1); DeleteFolderDeep(root2);
+}
 
-    // Test Case 3: Single sandbox root - path outside root
-    {
-        LOG("Test Case 3: Path outside a single sandbox root.");
-        McpServer server(1234, 1);
-        String root = NormalizePath(GetExeFolder() + "/test_sandbox_area_2");
-        RealizeDirectory(root);
-        server.AddSandboxRoot(root);
-        LOG("  Added root: " + root);
+TEST(Sandbox_PathIsRoot)
+{
+    McpServer server(1234, 1);
+    String root = NormalizePath(GetExeFolder() + "/test_sandbox_exact");
+    RealizeDirectory(root);
+    server.AddSandboxRoot(root);
+    server.EnforceSandbox(root);
+    DeleteFolderDeep(root);
+}
 
-        String outside_path = NormalizePath(GetExeFolder() + "/some_other_area/file_denied.txt");
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox(outside_path);
-            LOG("  FAILED: No exception for path outside the root.");
-            exit_code = 1;
-        } catch (const String& e) {
-            LOG("  PASSED: Expected exception thrown: " + e);
-            if (e.Find("Sandbox violation") < 0) {
-                LOG("  WARNING: Exception message might not be as expected: " + e);
-            }
-            exception_thrown = true;
-        }
-        ASSERT(exception_thrown);
-        DeleteFolderDeep(root); // Clean up
+TEST(Sandbox_TrickyPathInside)
+{
+    McpServer server(1234, 1);
+    String root = NormalizePath(GetExeFolder() + "/test_sandbox_parent");
+    String child = AppendFileName(root, "child");
+    RealizeDirectory(child);
+    server.AddSandboxRoot(root);
+    String tricky = AppendFileName(child, "../file_in_root.txt");
+    server.EnforceSandbox(tricky);
+    DeleteFolderDeep(root);
+}
+
+TEST(Sandbox_TrickyPathEscape)
+{
+    McpServer server(1234, 1);
+    String root = NormalizePath(GetExeFolder() + "/test_sandbox_escape");
+    RealizeDirectory(root);
+    server.AddSandboxRoot(root);
+    String tricky = AppendFileName(root, "../../escaped_file.txt");
+    bool threw = false;
+    try {
+        server.EnforceSandbox(tricky);
+    } catch(...) {
+        threw = true;
     }
-
-    // Test Case 4: Multiple sandbox roots
-    {
-        LOG("Test Case 4: Multiple sandbox roots.");
-        McpServer server(1234, 1);
-        String root1 = NormalizePath(GetExeFolder() + "/test_sandbox_multi_1");
-        String root2 = NormalizePath(GetExeFolder() + "/test_sandbox_multi_2");
-        RealizeDirectory(root1); RealizeDirectory(root2);
-        server.AddSandboxRoot(root1);
-        server.AddSandboxRoot(root2);
-        LOG("  Added roots: " + root1 + ", " + root2);
-
-        bool path1_allowed = false;
-        bool path2_allowed = false;
-        bool path_outside_allowed = true; // Should be false after test
-
-        try {
-            server.EnforceSandbox(AppendFileName(root1, "file.txt"));
-            path1_allowed = true;
-        } catch (...) {}
-
-        try {
-            server.EnforceSandbox(AppendFileName(root2, "another.txt"));
-            path2_allowed = true;
-        } catch (...) {}
-
-        try {
-            server.EnforceSandbox(NormalizePath(GetExeFolder() + "/outside_multi/other.txt"));
-            // Should throw
-        } catch (const String& e) {
-            path_outside_allowed = false; // Correctly denied
-        }
-
-        if (path1_allowed && path2_allowed && !path_outside_allowed) {
-            LOG("  PASSED: Paths within multiple roots allowed, path outside denied.");
-        } else {
-            LOG("  FAILED: Logic error with multiple roots. path1_ok=" + AsString(path1_allowed) +
-                ", path2_ok=" + AsString(path2_allowed) + ", path_outside_denied=" + AsString(!path_outside_allowed));
-            exit_code = 1;
-        }
-        ASSERT(path1_allowed && path2_allowed && !path_outside_allowed);
-        DeleteFolderDeep(root1); DeleteFolderDeep(root2);
-    }
-
-    // Test Case 5: Path is exactly a sandbox root
-    {
-        LOG("Test Case 5: Path is exactly a sandbox root.");
-        McpServer server(1234, 1);
-        String root = NormalizePath(GetExeFolder() + "/test_sandbox_exact");
-        RealizeDirectory(root);
-        server.AddSandboxRoot(root);
-         LOG("  Added root: " + root);
-
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox(root); // Path is the root itself
-            LOG("  PASSED: No exception for path being exactly a root.");
-        } catch (const String& e) {
-            LOG("  FAILED: Exception for path being exactly a root: " + e);
-            exception_thrown = true;
-            exit_code = 1;
-        }
-        ASSERT(!exception_thrown);
-        DeleteFolderDeep(root);
-    }
-
-    // Test Case 6: Child path of a root that contains '..' but still resolves within sandbox
-    {
-        LOG("Test Case 6: Path with '..' but resolves inside sandbox.");
-        McpServer server(1234, 1);
-        String root = NormalizePath(GetExeFolder() + "/test_sandbox_parent");
-        String childDir = AppendFileName(root, "child");
-        RealizeDirectory(childDir);
-        server.AddSandboxRoot(root);
-        LOG("  Added root: " + root);
-
-        String trickyPath = AppendFileName(childDir, "../file_in_root.txt");
-        // This resolves to GetExeFolder() + "/test_sandbox_parent/file_in_root.txt"
-        // which is inside the sandbox. NormalizePath handles '..'.
-
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox(trickyPath);
-            LOG("  PASSED: No exception for tricky path resolving inside sandbox.");
-        } catch (const String& e) {
-            LOG("  FAILED: Exception for tricky path: " + e);
-            exception_thrown = true;
-            exit_code = 1;
-        }
-        ASSERT(!exception_thrown);
-        DeleteFolderDeep(root);
-    }
-
-    // Test Case 7: Path with '..' that attempts to escape sandbox
-    {
-        LOG("Test Case 7: Path with '..' attempting to escape sandbox.");
-        McpServer server(1234, 1);
-        String root = NormalizePath(GetExeFolder() + "/test_sandbox_escape");
-        RealizeDirectory(root);
-        server.AddSandboxRoot(root);
-        LOG("  Added root: " + root);
-
-        String trickyPath = AppendFileName(root, "../../escaped_file.txt");
-        // This resolves to GetExeFolder() + "/../escaped_file.txt" (one level above exe dir)
-        // which should be outside the sandbox root.
-
-        bool exception_thrown = false;
-        try {
-            server.EnforceSandbox(trickyPath);
-            LOG("  FAILED: No exception for path escaping sandbox with '..'. Path: " + NormalizePath(trickyPath));
-            exit_code = 1;
-        } catch (const String& e) {
-            LOG("  PASSED: Expected exception for sandbox escape attempt: " + e);
-            exception_thrown = true;
-        }
-        ASSERT(exception_thrown);
-        DeleteFolderDeep(root);
-    }
-
-
-    if (exit_code == 0) {
-        LOG("--- All Sandbox Tests PASSED ---");
-    } else {
-        LOG("--- Some Sandbox Tests FAILED ---");
-    }
-    SetExitCode(exit_code);
+    ASSERT(threw);
+    DeleteFolderDeep(root);
 }


### PR DESCRIPTION
## Summary
- add lightweight test framework macros in `test_helpers.h`
- rewrite sandbox and permission tests using `TEST` macros
- add a simple `test_main.cpp` to run all tests
- update package and CMake files to build one `McpServerTests` executable

## Testing
- `cmake ../tests` *(fails: cannot find `Core/Core.h`)*
- `make` *(fails: missing U++ headers)*

------
https://chatgpt.com/codex/tasks/task_e_684566385750832e84d38f832fa6339e