### PR TITLE
Fix splash screen version and copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) YYYY [Your Name or Organization Here]
+Copyright (c) 2025 Curtis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/McpServerGUI/McpSplash.cpp
+++ b/McpServerGUI/McpSplash.cpp
@@ -54,9 +54,9 @@ void McpSplash::UpdateInfoText()
 {
     StringStream ss; // Use StringStream to build the display text
 
-    // Application Name and Version (example)
-    ss << "MCP Server v0.1.0 (Alpha)\n"; // TODO: Make version dynamic
-    ss << "Copyright (c) YYYY [Your Name Here]\n\n"; // TODO: Update copyright year/name
+    // Application Name and Version
+    ss << "MCP Server v" << MCP_SERVER_VERSION << " (Alpha)\n";
+    ss << "Copyright (c) 2025 Curtis\n\n";
 
     // Active Permissions
     ss << "**Current Permissions:**\n";

--- a/include/McpServer.h
+++ b/include/McpServer.h
@@ -2,6 +2,9 @@
 #include <Core/Core.h>
 #include "../mcp_server_lib/WebSocket.h"
 
+// Current application version
+constexpr const char* MCP_SERVER_VERSION = "0.1.0";
+
 using namespace Upp;
 
 struct Permissions { /* ... remains same ... */


### PR DESCRIPTION
## Summary
- keep track of MCP_SERVER_VERSION in `McpServer.h`
- show version constant and copyright on splash
- fill out license year and owner

## Testing
- `cmake .. && make -j4` *(fails: The source directory does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6845662c0984832e9b0c7e0b6377a30a