### PR TITLE
Fix license year/name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) YYYY [Your Name or Organization Here]
+Copyright (c) 2025 Curtis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update MIT license with proper year and copyright

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684566220e94832e8be14130f0426b78